### PR TITLE
Remove clippy warnings

### DIFF
--- a/src/environment.rs
+++ b/src/environment.rs
@@ -1,8 +1,8 @@
 use crate::namespace::{Namespace, Namespaces};
-use crate::rust_core;
-use crate::value::{ToValue, Value};
-use crate::Symbol;
 use crate::repl;
+use crate::rust_core;
+use crate::symbol::Symbol;
+use crate::value::{ToValue, Value};
 
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -68,21 +68,21 @@ impl Environment {
     }
     pub fn clojure_core_environment() -> Rc<Environment> {
         // Register our macros / functions ahead of time
-	let add_fn = rust_core::AddFn {};
-	let str_fn = rust_core::StrFn {};
-	let do_fn = rust_core::DoFn {};
-	let nth_fn = rust_core::NthFn {};
-	let do_macro = rust_core::DoMacro {};
-	let concat_fn = rust_core::ConcatFn {};
-	let print_string_fn = rust_core::PrintStringFn {};
-	// Hardcoded fns
-	let lexical_eval_fn = Value::LexicalEvalFn {};
-	// Hardcoded macros
-	let let_macro = Value::LetMacro {};
-	let quote_macro = Value::QuoteMacro {};
-	let def_macro = Value::DefMacro {};
-	let fn_macro = Value::FnMacro {};
-	let defmacro_macro = Value::DefmacroMacro {};
+        let add_fn = rust_core::AddFn {};
+        let str_fn = rust_core::StrFn {};
+        let do_fn = rust_core::DoFn {};
+        let nth_fn = rust_core::NthFn {};
+        let do_macro = rust_core::DoMacro {};
+        let concat_fn = rust_core::ConcatFn {};
+        let print_string_fn = rust_core::PrintStringFn {};
+        // Hardcoded fns
+        let lexical_eval_fn = Value::LexicalEvalFn {};
+        // Hardcoded macros
+        let let_macro = Value::LetMacro {};
+        let quote_macro = Value::QuoteMacro {};
+        let def_macro = Value::DefMacro {};
+        let fn_macro = Value::FnMacro {};
+        let defmacro_macro = Value::DefmacroMacro {};
         let environment = Rc::new(Environment::new_main_environment());
 
         let eval_fn = rust_core::EvalFn::new(Rc::clone(&environment));
@@ -96,33 +96,33 @@ impl Environment {
         environment.insert(Symbol::intern("defmacro"), defmacro_macro.to_rc_value());
         environment.insert(Symbol::intern("eval"), eval_fn.to_rc_value());
 
-	environment.insert(Symbol::intern("+"), add_fn.to_rc_value());
-	environment.insert(Symbol::intern("let"), let_macro.to_rc_value());
-	environment.insert(Symbol::intern("str"), str_fn.to_rc_value());
-	environment.insert(Symbol::intern("quote"), quote_macro.to_rc_value());
-	environment.insert(Symbol::intern("do-fn*"), do_fn.to_rc_value());
-	environment.insert(Symbol::intern("do"), do_macro.to_rc_value());
-	environment.insert(Symbol::intern("def"), def_macro.to_rc_value());
-	environment.insert(Symbol::intern("fn"), fn_macro.to_rc_value());
-	environment.insert(Symbol::intern("defmacro"), defmacro_macro.to_rc_value());
-	environment.insert(Symbol::intern("eval"), eval_fn.to_rc_value());
-	environment.insert(
+        environment.insert(Symbol::intern("+"), add_fn.to_rc_value());
+        environment.insert(Symbol::intern("let"), let_macro.to_rc_value());
+        environment.insert(Symbol::intern("str"), str_fn.to_rc_value());
+        environment.insert(Symbol::intern("quote"), quote_macro.to_rc_value());
+        environment.insert(Symbol::intern("do-fn*"), do_fn.to_rc_value());
+        environment.insert(Symbol::intern("do"), do_macro.to_rc_value());
+        environment.insert(Symbol::intern("def"), def_macro.to_rc_value());
+        environment.insert(Symbol::intern("fn"), fn_macro.to_rc_value());
+        environment.insert(Symbol::intern("defmacro"), defmacro_macro.to_rc_value());
+        environment.insert(Symbol::intern("eval"), eval_fn.to_rc_value());
+        environment.insert(
             Symbol::intern("lexical-eval"),
             lexical_eval_fn.to_rc_value(),
-	);
+        );
 
-	environment.insert(Symbol::intern("nth"), nth_fn.to_rc_value());
-	environment.insert(Symbol::intern("concat"), concat_fn.to_rc_value());
-	environment.insert(
+        environment.insert(Symbol::intern("nth"), nth_fn.to_rc_value());
+        environment.insert(Symbol::intern("concat"), concat_fn.to_rc_value());
+        environment.insert(
             Symbol::intern("print-string"),
             print_string_fn.to_rc_value(),
-	);
+        );
 
-	//
-	// Read in clojure.core
-	//
-	let _ = repl::try_eval_file(&environment, "./src/clojure/core.clj");
-	
-	environment 
+        //
+        // Read in clojure.core
+        //
+        let _ = repl::try_eval_file(&environment, "./src/clojure/core.clj");
+
+        environment
     }
 }

--- a/src/ifn.rs
+++ b/src/ifn.rs
@@ -15,7 +15,6 @@ use crate::value::Value;
 use dyn_clone::DynClone;
 
 use std::fmt::Debug;
-use std::hash::Hash;
 
 //
 // Based on: clojure.lang.IFn

--- a/src/lambda.rs
+++ b/src/lambda.rs
@@ -26,7 +26,7 @@ impl IFn for Fn {
         let argc = self.arg_syms.len();
 
         let mut var_args = false;
-        if (argc >= 2) {
+        if argc >= 2 {
             if let Some(sym) = self.arg_syms.get(argc - 2) {
                 if sym.to_string() == "&" {
                     var_args = true;
@@ -48,7 +48,7 @@ impl IFn for Fn {
             let curr_sym = self.arg_syms.get(i).unwrap();
             // We can bind the rest of the arguments, then, to the next variable and blow this popsicle stand
             if curr_sym.to_string() == "&" {
-                if (!var_args) {
+                if !var_args {
                     return Value::Condition(String::from("Invalid function argument '&' in non-variable-argument function definition"));
                 }
                 let last_sym = self.arg_syms.get(i + 1).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,19 +16,6 @@ mod symbol;
 mod type_tag;
 mod value;
 
-use environment::Environment;
-
-use std::io::BufRead;
-use std::io::{self};
-use std::io::Write;
-use std::rc::Rc;
-
-use crate::value::Value;
-use crate::value::{Evaluable, ToValue};
-use symbol::Symbol;
-
-use nom::Err::Incomplete;
-
 fn main() {
     //
     // Start repl

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -1,7 +1,5 @@
-use crate::rust_core::{AddFn, StrFn};
-use crate::value::ToValue;
+use crate::symbol::Symbol;
 use crate::value::Value;
-use crate::Symbol;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;

--- a/src/persistent_list.rs
+++ b/src/persistent_list.rs
@@ -4,7 +4,7 @@ use std::iter::FromIterator;
 use std::rc::Rc;
 
 use crate::value::{ToValue, Value};
-use std::hash::{Hash, Hasher};
+use std::hash::Hash;
 
 #[derive(Debug, Clone, PartialEq, Hash)]
 pub enum PersistentList {

--- a/src/persistent_list_map.rs
+++ b/src/persistent_list_map.rs
@@ -172,6 +172,8 @@ impl fmt::Display for PersistentListMap {
 mod tests {
     use crate::persistent_list_map::*;
     use crate::value::ToValue;
+    use crate::symbol::Symbol;
+
     #[test]
     fn test_persistent_list_map() {
         let empty = PersistentListMap::Empty;

--- a/src/persistent_list_map.rs
+++ b/src/persistent_list_map.rs
@@ -171,8 +171,8 @@ impl fmt::Display for PersistentListMap {
 #[cfg(test)]
 mod tests {
     use crate::persistent_list_map::*;
-    use crate::value::ToValue;
     use crate::symbol::Symbol;
+    use crate::value::ToValue;
 
     #[test]
     fn test_persistent_list_map() {

--- a/src/persistent_list_map.rs
+++ b/src/persistent_list_map.rs
@@ -14,7 +14,6 @@
 //! b => {:a 1 :b 3}
 
 use crate::maps::MapEntry;
-use crate::symbol::Symbol;
 use crate::value::Value;
 
 use std::collections::HashMap;

--- a/src/persistent_vector.rs
+++ b/src/persistent_vector.rs
@@ -1,7 +1,7 @@
 use std::convert::From;
 use std::fmt;
 use std::fmt::Debug;
-use std::hash::{Hash, Hasher};
+use std::hash::Hash;
 use std::iter::FromIterator;
 use std::rc::Rc;
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -9,25 +9,17 @@
 //! power, neither speed or ecosystem,  it might be worth it to leave in reader macros.
 
 use nom::{
-    branch::alt,
-    bytes::complete::{tag, take_while1},
-    character::complete::multispace0,
-    combinator::map_res,
-    error::convert_error,
-    map,
-    sequence::{preceded, terminated},
-    take_until, terminated, IResult,
+    branch::alt, bytes::complete::tag, map, sequence::preceded, take_until, terminated, IResult,
 };
 
 use crate::maps::MapEntry;
 use crate::persistent_list::ToPersistentList;
-use crate::persistent_list_map::{PersistentListMap, ToPersistentListMap};
+use crate::persistent_list_map::ToPersistentListMap;
 use crate::persistent_vector::ToPersistentVector;
 use crate::symbol::Symbol;
 use crate::value::{ToValue, Value};
-use std::{iter::FromIterator, rc::Rc};
+use std::rc::Rc;
 
-use std::fs::File;
 //
 // Note; the difference between ours 'parsers'
 //   identifier_parser
@@ -42,7 +34,7 @@ use std::fs::File;
 //
 // Is our parsers are meant to be be nom parsers, and more primitive in that
 // they can parse any information that we can later use to create a value::Value
-// 
+//
 // Our 'try readers' are a bit higher level, and are specifically supposed to be returning a valid // value::Value or some sort of failure.
 //
 
@@ -308,7 +300,7 @@ pub fn debug_try_read(input: &str) -> IResult<&str, Value> {
 }
 
 /// Consumes any whitespace from input, if there is any.
-/// Always succeeds. 
+/// Always succeeds.
 ///
 /// A whitespace is either an ASCII whitespace or a comma.
 fn consume_clojure_whitespaces(input: &str) -> IResult<&str, ()> {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -203,6 +203,7 @@ pub fn try_read_string(input: &str) -> IResult<&str, Value> {
     named!(quotation<&str, &str>, preceded!(consume_clojure_whitespaces, tag!("\"")));
 
     let (rest_input, _) = quotation(input)?;
+
     named!(
         string_parser<&str, String>,
         map!(
@@ -211,7 +212,7 @@ pub fn try_read_string(input: &str) -> IResult<&str, Value> {
         )
     );
 
-    to_value_parser(string_parser)(input)
+    to_value_parser(string_parser)(rest_input)
 }
 
 // @TODO Perhaps generalize this, or even generalize it as a reader macro

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -1,8 +1,8 @@
 use std::fs::File;
 use std::io::BufRead;
 use std::io::BufReader;
-use std::io::{self};
 use std::io::Write;
+use std::io;
 
 use crate::environment::Environment;
 use crate::reader;
@@ -33,10 +33,10 @@ pub fn try_eval_file(environment: &Rc<Environment>, filepath: &str) -> Result<()
                     //print!("{} ",value.eval(Rc::clone(&environment)).to_string_explicit());
                     value.eval(Rc::clone(&environment));
                     remaining_input = _remaining_input;
-                },
+                }
                 Err(Incomplete(Size(1))) => {
                     break;
-                },
+                }
                 err => {
                     println!(
                         "Error evaluating file {}; {}",
@@ -44,7 +44,7 @@ pub fn try_eval_file(environment: &Rc<Environment>, filepath: &str) -> Result<()
                         Value::Condition(format!("Reader Error: {:?}", err))
                     );
                     input_buffer.clear();
-                    remaining_input = "";
+                    // remaining_input = "";
                     break;
                 }
             }
@@ -54,7 +54,7 @@ pub fn try_eval_file(environment: &Rc<Environment>, filepath: &str) -> Result<()
     Ok(())
 }
 // @TODO eventually, this will likely be implemented purely in Clojure
-/// Starts an entirely new session of Clojure RS 
+/// Starts an entirely new session of Clojure RS
 pub fn repl() {
     println!("Clojure RS 0.0.1");
 
@@ -91,6 +91,6 @@ pub fn repl() {
         input_buffer.clear();
         println!();
         print!("user=> ");
-	let _ = io::stdout().flush();
+        let _ = io::stdout().flush();
     }
 }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -1,8 +1,8 @@
 use std::fs::File;
+use std::io;
 use std::io::BufRead;
 use std::io::BufReader;
 use std::io::Write;
-use std::io;
 
 use crate::environment::Environment;
 use crate::reader;

--- a/src/rust_core.rs
+++ b/src/rust_core.rs
@@ -3,16 +3,14 @@ use std::rc::Rc;
 
 use crate::environment::Environment;
 use crate::ifn::IFn;
-use crate::lambda::Fn;
 use crate::persistent_list::{
     PersistentList,
     PersistentList::{Cons, Empty},
     ToPersistentList, ToPersistentListIter,
 };
-use crate::persistent_vector::{PersistentVector, ToPersistentVector, ToPersistentVectorIter};
+use crate::persistent_vector::{PersistentVector, ToPersistentVectorIter};
 use crate::symbol::Symbol;
 use crate::value::{Evaluable, ToValue};
-use std::collections::HashMap;
 
 //
 // This module will hold the core functions and macros that Clojure will

--- a/src/rust_core.rs
+++ b/src/rust_core.rs
@@ -149,7 +149,7 @@ impl ToValue for DoMacro {
 impl IFn for DoMacro {
     fn invoke(&self, args: Vec<&Value>) -> Value {
         // @TODO generalize arity exceptions, and other exceptions
-        if args.len() == 0 {
+        if args.is_empty() {
             return vec![Symbol::intern("do").to_rc_value(), Rc::new(Value::Nil)]
                 .into_list()
                 .to_value();

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -1,5 +1,5 @@
 use std::fmt;
-use std::hash::{Hash, Hasher};
+use std::hash::Hash;
 
 #[derive(Hash, PartialEq, Eq, Clone, Debug)]
 pub struct Symbol {

--- a/src/value.rs
+++ b/src/value.rs
@@ -2,24 +2,20 @@ use crate::environment::Environment;
 use crate::ifn::IFn;
 use crate::lambda;
 use crate::maps::MapEntry;
-use crate::persistent_list::PersistentList::{Cons, Empty};
+use crate::persistent_list::PersistentList::Cons;
 use crate::persistent_list::{PersistentList, ToPersistentList, ToPersistentListIter};
 use crate::persistent_list_map::{PersistentListMap, ToPersistentListMapIter};
-use crate::persistent_vector::{PersistentVector, ToPersistentVector, ToPersistentVectorIter};
+use crate::persistent_vector::PersistentVector;
 use crate::symbol::Symbol;
 use crate::type_tag::TypeTag;
 
 extern crate rand;
 use rand::Rng;
 
-use std::collections::HashMap;
 use std::fmt;
 use std::fmt::Debug;
 use std::hash::{Hash, Hasher};
-use std::iter::FromIterator;
 use std::rc::Rc;
-
-use std::ops::Deref;
 
 // @TODO Change IFn's name -- IFn is a function, not an IFn.
 //       The body it executes just happens to be an the IFn.
@@ -82,8 +78,8 @@ impl PartialEq for Value {
         }
         // Equality not defined on functions, similar to Clojure
         // Change this perhaps? Diverge?
-        if let IFn(ifn) = self {
-            if let IFn(ifn2) = other {
+        if let IFn(_) = self {
+            if let IFn(_) = other {
                 return false;
             }
         }


### PR DESCRIPTION
This branch will remove completely warnings emitted by clippy. This should fix #18. Further additional refactoring will be needed in order to close #12, but we're progressing toward it.