### PR TITLE
boolean type and unit tests

### DIFF
--- a/src/type_tag.rs
+++ b/src/type_tag.rs
@@ -3,6 +3,7 @@ use std::fmt;
 #[derive(Debug, Clone)]
 pub enum TypeTag {
     I32,
+    Boolean,
     Symbol,
     Keyword,
     IFn,
@@ -17,14 +18,16 @@ pub enum TypeTag {
     ISeq,
     Nil
 }
+
 use TypeTag::*;
 impl fmt::Display for TypeTag {
     // This trait requires `fmt` with this exact signature.
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let str = match self {
             I32 => std::string::String::from("rust.std.i32"),
+            Boolean => std::string::String::from("rust.std.bool"),
             Symbol => std::string::String::from("clojure.lang.Symbol"),
-	    Keyword => std::string::String::from("clojure.lang.Keyword"),
+	        Keyword => std::string::String::from("clojure.lang.Keyword"),
             IFn => std::string::String::from("clojure.lang.Function"),
             Condition => std::string::String::from("clojure.lang.Condition"),
             PersistentList => std::string::String::from("clojure.lang.PersistentList"),

--- a/src/value.rs
+++ b/src/value.rs
@@ -28,6 +28,7 @@ use std::rc::Rc;
 #[derive(Debug, Clone)]
 pub enum Value {
     I32(i32),
+    Boolean(bool),
     Symbol(Symbol),
     Keyword(Keyword),
     IFn(Rc<dyn IFn>),
@@ -71,6 +72,12 @@ impl PartialEq for Value {
         if let I32(i) = self {
             if let I32(i2) = other {
                 return i == i2;
+            }
+        }
+
+        if let Boolean(b) = self {
+            if let Boolean(b2) = other {
+                return b == b2;
             }
         }
 
@@ -180,6 +187,7 @@ impl Hash for Value {
     fn hash<H: Hasher>(&self, state: &mut H) {
         match self {
             I32(i) => i.hash(state),
+            Boolean(b) => b.hash(state),
             Symbol(sym) => sym.hash(state),
 	    Keyword(kw) => kw.hash(state),
             IFn(_) => {
@@ -216,6 +224,7 @@ impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let str = match self {
             I32(val) => val.to_string(),
+            Boolean(val) => val.to_string(),
             Symbol(sym) => sym.to_string(),
 	    Keyword(kw) => kw.to_string(),
             IFn(_) => std::string::String::from("#function[]"),
@@ -254,6 +263,7 @@ impl Value {
     pub fn type_tag(&self) -> TypeTag {
         match self {
             Value::I32(_) => TypeTag::I32,
+            Value::Boolean(_) => TypeTag::Boolean,
             Value::Symbol(_) => TypeTag::Symbol,
 	    Value::Keyword(_) => TypeTag::Keyword,
             Value::IFn(_) => TypeTag::IFn,
@@ -588,6 +598,11 @@ impl ToValue for Rc<Value> {
 impl ToValue for i32 {
     fn to_value(&self) -> Value {
         Value::I32(*self)
+    }
+}
+impl ToValue for bool {
+    fn to_value(&self) -> Value {
+        Value::Boolean(*self)
     }
 }
 impl ToValue for std::string::String {


### PR DESCRIPTION
Adds boolean type

Some strange things still going on, I don't know if they're features currently but it's needed to use `quote`

```
user=> true
true
user=> false
false
user=> (def a true)
a
user=> a
#Condition["Undefined symbol true"]
user=> (def a (quote true))
a
user=> a
true
user=> (def m {(quote true) (quote false) (quote false) (quote true) :a true})
m
user=> m
{true false, false true, :a #Condition["Undefined symbol true"]}
user=>
```