### PR TITLE
f64 type, addition works with doubles and ints together

### DIFF
--- a/src/rust_core.rs
+++ b/src/rust_core.rs
@@ -70,9 +70,18 @@ impl IFn for AddFn {
         args.into_iter().fold(0_i32.to_value(), |a, b| match a {
             Value::I32(a_) => match *b {
                 Value::I32(b_) => Value::I32(a_ + b_),
+                Value::F64(b_) => Value::F64(a_ as f64 + b_),
                 _ => Value::Condition(format!( // TODO: what error message should be returned regarding using typetags?
                     "Type mismatch; Expecting: (i32 | i64 | f32 | f64), Found: {}",
                     b.type_tag()
+                )),
+            },
+            Value::F64(a_) => match *b {
+                Value::I32(b_) => Value::F64(a_ + b_ as f64),
+                Value::F64(b_) => Value::F64(a_ + b_),
+                _ => Value::Condition(format!( // TODO: what error message should be returned regarding using typetags?
+                                               "Type mismatch; Expecting: (i32 | i64 | f32 | f64), Found: {}",
+                                               b.type_tag()
                 )),
             },
             _ => Value::Condition(format!( // TODO: what error message should be returned regarding using typetags?

--- a/src/type_tag.rs
+++ b/src/type_tag.rs
@@ -3,6 +3,7 @@ use std::fmt;
 #[derive(Debug, Clone)]
 pub enum TypeTag {
     I32,
+    F64,
     Boolean,
     Symbol,
     Keyword,
@@ -26,6 +27,7 @@ impl fmt::Display for TypeTag {
         let str = match self {
             I32 => std::string::String::from("rust.std.i32"),
             Boolean => std::string::String::from("rust.std.bool"),
+            F64 => std::string::String::from("rust.std.f64"),
             Symbol => std::string::String::from("clojure.lang.Symbol"),
 	        Keyword => std::string::String::from("clojure.lang.Keyword"),
             IFn => std::string::String::from("clojure.lang.Function"),

--- a/src/value.rs
+++ b/src/value.rs
@@ -28,6 +28,7 @@ use std::rc::Rc;
 #[derive(Debug, Clone)]
 pub enum Value {
     I32(i32),
+    F64(f64),
     Boolean(bool),
     Symbol(Symbol),
     Keyword(Keyword),
@@ -72,6 +73,12 @@ impl PartialEq for Value {
         if let I32(i) = self {
             if let I32(i2) = other {
                 return i == i2;
+            }
+        }
+
+        if let F64(d) = self {
+            if let F64(d2) = other {
+                return d == d2;
             }
         }
 
@@ -187,6 +194,7 @@ impl Hash for Value {
     fn hash<H: Hasher>(&self, state: &mut H) {
         match self {
             I32(i) => i.hash(state),
+            F64(d) => d.to_value().hash(state),
             Boolean(b) => b.hash(state),
             Symbol(sym) => sym.hash(state),
 	    Keyword(kw) => kw.hash(state),
@@ -224,6 +232,7 @@ impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let str = match self {
             I32(val) => val.to_string(),
+            F64(val) => val.to_string(),
             Boolean(val) => val.to_string(),
             Symbol(sym) => sym.to_string(),
 	    Keyword(kw) => kw.to_string(),
@@ -263,6 +272,7 @@ impl Value {
     pub fn type_tag(&self) -> TypeTag {
         match self {
             Value::I32(_) => TypeTag::I32,
+            Value::F64(_) => TypeTag::F64,
             Value::Boolean(_) => TypeTag::Boolean,
             Value::Symbol(_) => TypeTag::Symbol,
 	    Value::Keyword(_) => TypeTag::Keyword,
@@ -598,6 +608,11 @@ impl ToValue for Rc<Value> {
 impl ToValue for i32 {
     fn to_value(&self) -> Value {
         Value::I32(*self)
+    }
+}
+impl ToValue for f64 {
+    fn to_value(&self) -> Value {
+        Value::F64(*self)
     }
 }
 impl ToValue for bool {


### PR DESCRIPTION
Solves #29 

* Double data type (f64) (double and not float because Clojure JVM uses Double by default)

Addition with promotion to double works:

```clojure
user=> (+ 1 1)
2
user=> (+ 1 1.2)
2.2
user=> (+ 1.1 1)
2.1
```